### PR TITLE
Replace compile scripts with Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,6 @@ examples:
 clean:
 	rm distjs/*.js
 	$(MAKE) -C examples clean
+
+format:
+	elm-format src/ examples/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+all: webmidi examples
+
+webmidi: distjs/elmWebMidi.js
+
+distjs/elmWebMidi.js: src/WebMidi.elm src/WebMidi/*.elm
+	elm-make src/WebMidi.elm --output distjs/elmWebMidi.js
+
+.PHONY: examples
+examples:
+	$(MAKE) -C examples all
+
+clean:
+	rm distjs/*.js
+	$(MAKE) -C examples clean

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ This version has one advantage over its predecessor - MIDI Event messages are no
 
 The only processing that is done on the message stream is to recognise volume control messages and thus to save to state the current maximum volume.  This allows programs that use the module to respond to the volume control as notes are played.
 
-You will need to attach a MIDI input device to your computer to see any effect from Web-MIDI. At the time of writing, Chrome has the best support. Recent versions of Opera and Firefox support it but playback seems unresponsive. Other browsers will fail to initialise or fail to respond (say) to key presses on a MIDI keyboard.
+You will need to attach a MIDI device to your computer to see any effect from Web-MIDI. At the time of writing, Chrome has the best support. Recent versions of Opera and Firefox support it but playback seems unresponsive. Other browsers will fail to initialise or fail to respond (say) to key presses on a MIDI keyboard.
 
-To build, invoke __compile.sh__ and browse to __webmidi.html__
+To build, run __make__ and browse to __webmidi.html__
 
 Testing
 -------
@@ -27,13 +27,13 @@ cd to the examples directory to see the sample programs.
 
 [Basic.elm](https://github.com/newlandsvalley/elm-webmidi-ports/blob/master/examples/src/basic/Basic.elm) is functionally identical to WebMidi.elm.  It simply illustrates how you might embed the WebMidi module inside a larger program (but in this case this program does nothing else).
 
-To build, invoke __compileb.sh__ and browse to __basic.html__.
-
 ### Piano
 
 [Piano.elm](https://github.com/newlandsvalley/elm-webmidi-ports/blob/master/examples/src/piano/Piano.elm) allows you to plug in your MIDI keyboard or other MIDI device and play it as a piano. It works simply by loading the piano soundfont which is served as a local resource, initialising web-midi and requesting that any NoteOn events should be played through the soundfont.
 
-To build, invoke __compilep.sh__ and browse to __piano.html__.
+### Send
+
+[Send.elm](https://github.com/newlandsvalley/elm-webmidi-ports/blob/master/examples/src/send/Send.elm) allows you to send MIDI note on and off messages to any connected MIDI device.
 
 ### Pick an Instrument
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,1 +1,0 @@
-elm-make src/WebMidi.elm --output distjs/elmWebMidi.js

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,0 +1,20 @@
+all: basicExample midiInstrumentExample pianoExample sendExample
+
+basicExample: distjs/elmBasic.js
+distjs/elmBasic.js: src/basic/Basic.elm
+	elm-make src/basic/Basic.elm --output distjs/elmBasic.js
+
+midiInstrumentExample: distjs/elmMidiInstrument.js
+distjs/elmMidiInstrument.js: src/midiInstrument/MidiInstrument.elm
+	elm-make src/midiInstrument/MidiInstrument.elm --output distjs/elmMidiInstrument.js
+
+pianoExample: distjs/elmPiano.js
+distjs/elmPiano.js: src/piano/Piano.elm
+	elm-make src/piano/Piano.elm --output distjs/elmPiano.js
+
+sendExample: distjs/elmSend.js
+distjs/elmSend.js: src/send/Send.elm
+	elm-make src/send/Send.elm --output distjs/elmSend.js
+
+clean:
+	rm distjs/*.js

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -18,3 +18,6 @@ distjs/elmSend.js: src/send/Send.elm
 
 clean:
 	rm distjs/*.js
+
+format:
+	elm-format src/

--- a/examples/compileb.sh
+++ b/examples/compileb.sh
@@ -1,1 +1,0 @@
-elm-make src/basic/Basic.elm --output distjs/elmBasic.js

--- a/examples/compilemi.sh
+++ b/examples/compilemi.sh
@@ -1,1 +1,0 @@
-elm-make src/midiInstrument/MidiInstrument.elm --output distjs/elmMidiInstrument.js

--- a/examples/compilep.sh
+++ b/examples/compilep.sh
@@ -1,1 +1,0 @@
-elm-make src/piano/Piano.elm --output distjs/elmPiano.js

--- a/examples/compiles.sh
+++ b/examples/compiles.sh
@@ -1,1 +1,0 @@
-elm-make src/send/Send.elm --output distjs/elmSend.js


### PR DESCRIPTION
Makefiles seemed a bit cleaner than having one script per-target. This should make Travis CI integration a little bit nicer too.